### PR TITLE
유저 api 리팩토링 및 생일 타입 수정

### DIFF
--- a/src/main/java/recreateyou/reqapi/user/entity/ProfileAttachmentEntity.java
+++ b/src/main/java/recreateyou/reqapi/user/entity/ProfileAttachmentEntity.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/recreateyou/reqapi/user/entity/UserEntity.java
+++ b/src/main/java/recreateyou/reqapi/user/entity/UserEntity.java
@@ -12,6 +12,7 @@ import recreateyou.reqapi.user.vo.UserRequestVO;
 import recreateyou.reqapi.user.vo.UserResponseVO;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class UserEntity {
     private String userName;        // 이름
 
     @Column(name = "BIRTH")
-    private Timestamp birth;        // 생년월일
+    private LocalDate birth;        // 생년월일
 
     @Column(name = "PHONE_NUMBER", length = 15)
     private String phoneNumber;     // 전화번호

--- a/src/main/java/recreateyou/reqapi/user/entity/UserEntity.java
+++ b/src/main/java/recreateyou/reqapi/user/entity/UserEntity.java
@@ -16,7 +16,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -88,24 +87,22 @@ public class UserEntity {
     @OneToMany(mappedBy = "userId")
     private List<NoticeEntity> noticeList;
 
-
-    public UserEntity(String userId,UserRequestVO requestVO, PasswordEncoder passwordEncoder) {
-        this.userId = userId;
-        this.userPw = passwordEncoder.encode(requestVO.userPW());
-        this.userName = requestVO.userName();
-        this.birth = requestVO.birth();
-        this.phoneNumber = requestVO.phoneNumber();
-        this.emailId = requestVO.emailId();
-        this.emailDomain = requestVO.emailDomain();
-        this.emailCheck = false;
-        this.zipCode = requestVO.zipCode();
-        this.gender = requestVO.gender();
+    public static UserEntity of(String userId,UserRequestVO requestVO, PasswordEncoder passwordEncoder) {
+        return UserEntity.builder()
+                .userId(userId)
+                .userPw(passwordEncoder.encode(requestVO.userPW()))
+                .userName(requestVO.userName())
+                .birth(requestVO.birth())
+                .phoneNumber(requestVO.phoneNumber())
+                .emailId(requestVO.emailId())
+                .emailDomain(requestVO.emailDomain())
+                .emailCheck(false)
+                .zipCode(requestVO.zipCode())
+                .gender(requestVO.gender())
+                .build();
     }
 
-    public UserResponseVO toResponseVo() {
-        return new UserResponseVO(this.getUserId(), this.getUserName(), this.getBirth(), this.getPhoneNumber(),
-                this.getEmailId(), this.getEmailDomain(), this.getEmailCheck(),
-                this.getZipCode(), this.getGender(), this.getFollowerCount(),
-                this.getUserRegDate(), this.getUserUpdDate(), this.getDeleted());
+    public void updateDeleted(boolean deleted) {
+        this.deleted = deleted;
     }
 }

--- a/src/main/java/recreateyou/reqapi/user/service/UserService.java
+++ b/src/main/java/recreateyou/reqapi/user/service/UserService.java
@@ -12,8 +12,6 @@ import recreateyou.reqapi.user.repository.UserRepository;
 import recreateyou.reqapi.user.vo.UserRequestVO;
 import recreateyou.reqapi.user.vo.UserResponseVO;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,23 +22,23 @@ public class UserService {
     private final AuthService authService;
 
     public void joinUser(String userId, UserRequestVO userRequestVO) {
-        userRepository.save(new UserEntity(userId, userRequestVO, bCryptPasswordEncoder));
+        userRepository.save(UserEntity.of(userId, userRequestVO, bCryptPasswordEncoder));
         authService.grantRole(userId, Role.USER);
     }
 
     public UserResponseVO getUser(@PathVariable("user-id") String userId) {
-        Optional<UserEntity> foundUser = userRepository.findById(userId);
-        UserEntity userEntity = foundUser.orElseThrow(() -> new RuntimeException("회원 정보 없음"));
-        return userEntity.toResponseVo();
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("회원 정보 없음"));
+        return UserResponseVO.from(userEntity);
     }
 
     public void deleteUser(@PathVariable("user-id") String userId) {
-        Optional<UserEntity> foundUser = userRepository.findById(userId);
-        UserEntity userEntity = foundUser.orElseThrow(() -> new RuntimeException("회원 정보 없음"));
-        userEntity.setDeleted(true);
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("회원 정보 없음"));
+        userEntity.updateDeleted(true);
     }
 
     public void putUser(@PathVariable("user-id") String userId, UserRequestVO requestVO) {
-        userRepository.save(new UserEntity(userId, requestVO, bCryptPasswordEncoder));
+        userRepository.save(UserEntity.of(userId, requestVO, bCryptPasswordEncoder));
     }
 }

--- a/src/main/java/recreateyou/reqapi/user/vo/UserRequestVO.java
+++ b/src/main/java/recreateyou/reqapi/user/vo/UserRequestVO.java
@@ -5,11 +5,12 @@ import org.springframework.lang.Nullable;
 import recreateyou.reqapi.user.enums.Gender;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 
 public record UserRequestVO(
         @NonNull String userPW,
         @NonNull String userName,
-        @Nullable Timestamp birth,
+        @Nullable LocalDate birth,
         @Nullable String phoneNumber,
         @NonNull String emailId,
         @NonNull String emailDomain,

--- a/src/main/java/recreateyou/reqapi/user/vo/UserResponseVO.java
+++ b/src/main/java/recreateyou/reqapi/user/vo/UserResponseVO.java
@@ -3,13 +3,13 @@ package recreateyou.reqapi.user.vo;
 import recreateyou.reqapi.user.entity.UserEntity;
 import recreateyou.reqapi.user.enums.Gender;
 
-import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record UserResponseVO(
         String userId,
         String userName,
-        Timestamp birth,
+        LocalDate birth,
         String phoneNumber,
         String emailId,
         String emailDomain,

--- a/src/main/java/recreateyou/reqapi/user/vo/UserResponseVO.java
+++ b/src/main/java/recreateyou/reqapi/user/vo/UserResponseVO.java
@@ -1,5 +1,6 @@
 package recreateyou.reqapi.user.vo;
 
+import recreateyou.reqapi.user.entity.UserEntity;
 import recreateyou.reqapi.user.enums.Gender;
 
 import java.sql.Timestamp;
@@ -20,4 +21,10 @@ public record UserResponseVO(
         LocalDateTime userUpdDate,
         Boolean deleted
 ) {
+    public static UserResponseVO from(UserEntity entity) {
+        return new UserResponseVO(entity.getUserId(), entity.getUserName(), entity.getBirth(), entity.getPhoneNumber(),
+                entity.getEmailId(), entity.getEmailDomain(), entity.getEmailCheck(),
+                entity.getZipCode(), entity.getGender(), entity.getFollowerCount(),
+                entity.getUserRegDate(), entity.getUserUpdDate(), entity.getDeleted());
+    }
 }


### PR DESCRIPTION
변경점

- `Entity` 클래스의 `setter` 제거

- 생일 필드의 타입을 `TimeStamp -> LocalDate` 로 변경.

`TimeStamp`는 레거시 코드인데... 왜썼는지 모르겠네요. 저번 리뷰때 밀리초 까지 나오는거 같다고 한게 생각나서 다시 확인해보고 수정했습니다. (이제 `yyyy-MM-dd` 형식으로 들어감)


- `Entity -> Vo` 또는 `Vo -> Entity` 변환시 `factory` 메서드 사용.

`new UserEntity(String userId,UserRequestVO requestVO, PasswordEncoder passwordEncoder)` 이 코드를 보다보니 좀 걸리는 부분이 있어 알아보니 `static method` 를 많이 추천하는 것 같아 적용해 보았습니다.

참고로 요즘 트랜드? 는 `MapStruct` 라는 라이브러리를 사용하는 것 같네요 `Lombok` 처럼 어노테이션으로 객체 변환 자동완성을 지원해주는 것 같습니다.



